### PR TITLE
fix order of nodes in templates

### DIFF
--- a/playbooks/create_groups.yml
+++ b/playbooks/create_groups.yml
@@ -30,5 +30,5 @@
         ansible_become_user: root
         ansible_become_pass: "{{ hostvars[item].ansible_ssh_pass|default('') }}"
         groups: ambari-node
-      with_items: "{{ groups['master-nodes']|sort|last }}"
+      with_items: "{{ groups['master-nodes'][-1] }}"
       when: "'ambari-node' not in groups or groups['ambari-node']|length < 1"

--- a/playbooks/roles/ambari-server/templates/cluster-template-custom.j2
+++ b/playbooks/roles/ambari-server/templates/cluster-template-custom.j2
@@ -25,7 +25,7 @@
     {% if groups['slave-nodes']|length > 0 -%}
     {
       "name" : "slavenode_simple",
-      "hosts" : [{% for node in groups['slave-nodes']|sort %}
+      "hosts" : [{% for node in groups['slave-nodes'] %}
 
         {
           "fqdn" : "{{ hostvars[node]['ansible_fqdn'] | lower }}"
@@ -39,11 +39,9 @@
     {
       "name" : "masternode_2",
       "hosts" : [
-{% for node in groups['master-nodes']|sort %}{% if loop.index == 2 %}
         {
-          "fqdn" : "{{ hostvars[node]['ansible_fqdn'] | lower }}"
+          "fqdn" : "{{ hostvars[groups['ambari-node'][1]]['ansible_fqdn'] | lower }}"
         }
-{% endif %}{% endfor %}
       ]
     },
     {% endif -%}
@@ -52,7 +50,7 @@
       "name" : "masternode_3",
       "hosts" : [
         {
-          "fqdn" : "{{ hostvars[groups['ambari-node'][0]]['ansible_fqdn'] | lower }}"
+          "fqdn" : "{{ hostvars[groups['master-nodes'][2]]['ansible_fqdn'] | lower }}"
         }
       ]
     },
@@ -60,7 +58,7 @@
     {% if 'edge-nodes' in groups and groups['edge-nodes']|length > 0 -%}
     {
       "name" : "edgenode",
-      "hosts" : [{% for node in groups['edge-nodes']|sort %}
+      "hosts" : [{% for node in groups['edge-nodes'] %}
 
         {
           "fqdn" : "{{ hostvars[node]['ansible_fqdn'] | lower }}"
@@ -74,7 +72,7 @@
       "name" : "masternode_1",
       "hosts" : [
         {
-          "fqdn" : "{{ hostvars[groups['master-nodes']|sort|first]['ansible_fqdn'] | lower }}"
+          "fqdn" : "{{ hostvars[groups['master-nodes'][0]]['ansible_fqdn'] | lower }}"
         }
       ]
     }

--- a/playbooks/roles/ambari-server/templates/cluster-template-multi-nodes.j2
+++ b/playbooks/roles/ambari-server/templates/cluster-template-multi-nodes.j2
@@ -25,7 +25,7 @@
     {% if groups['slave-nodes']|length > 0 and not (groups['slave-nodes']|length == 1 and groups['master-nodes']|length == 2) -%}
     {
       "name" : "slavenode_simple",
-      "hosts" : [{% for node in groups['slave-nodes']|sort %}{% if groups['master-nodes']|length == 2 %}{% if not loop.first %}
+      "hosts" : [{% for node in groups['slave-nodes'] %}{% if groups['master-nodes']|length == 2 %}{% if not loop.first %}
 
         {
           "fqdn" : "{{ hostvars[node]['ansible_fqdn'] | lower }}"
@@ -47,11 +47,9 @@
     {
       "name" : "masternode_2",
       "hosts" : [
-{% for node in groups['master-nodes']|sort %}{% if loop.index == 2 %}
         {
-          "fqdn" : "{{ hostvars[node]['ansible_fqdn'] | lower }}"
+          "fqdn" : "{{ hostvars[groups['master-nodes'][1]]['ansible_fqdn'] | lower }}"
         }
-{% endif %}{% endfor %}
       ]
     },
     {% endif -%}
@@ -60,7 +58,7 @@
       "name" : "masternode_3",
       "hosts" : [
         {
-          "fqdn" : "{{ hostvars[groups['ambari-node'][0]]['ansible_fqdn'] | lower }}"
+          "fqdn" : "{{ hostvars[groups['master-nodes'][2]]['ansible_fqdn'] | lower }}"
         }
       ]
     },
@@ -68,7 +66,7 @@
     {% if 'edge-nodes' in groups and groups['edge-nodes']|length > 0 -%}
     {
       "name" : "edgenode",
-      "hosts" : [{% for node in groups['edge-nodes']|sort %}
+      "hosts" : [{% for node in groups['edge-nodes'] %}
 
         {
           "fqdn" : "{{ hostvars[node]['ansible_fqdn'] | lower }}"
@@ -83,7 +81,7 @@
       "name" : "slavenode_zookeeper",
       "hosts" : [
         {
-          "fqdn" : "{{ hostvars[groups['slave-nodes']|sort|first]['ansible_fqdn'] | lower }}"
+          "fqdn" : "{{ hostvars[groups['slave-nodes'][0]]['ansible_fqdn'] | lower }}"
         }
       ]
     },
@@ -92,7 +90,7 @@
       "name" : "masternode_1",
       "hosts" : [
         {
-          "fqdn" : "{{ hostvars[groups['master-nodes']|sort|first]['ansible_fqdn'] | lower }}"
+          "fqdn" : "{{ hostvars[groups['master-nodes'][0]]['ansible_fqdn'] | lower }}"
         }
       ]
     }


### PR DESCRIPTION
- using the python array index rather than sort|(first|last|index)
